### PR TITLE
Chef 14 compatibility fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,5 @@ Style/NumericLiteralPrefix:
 Metrics/LineLength:
   Max: 120
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
-Style/WhileUntilModifier:
-  MaxLineLength: 120
-
 Metrics/BlockLength:
   Enabled: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,9 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start! { add_filter 'yum-nvidia' }
-
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.4.1708',
+  version: '7',
 }.freeze
 
 ALL_PLATFORMS = [
@@ -13,5 +11,5 @@ ALL_PLATFORMS = [
 ].freeze
 
 RSpec.configure do |config|
-  config.log_level = :fatal
+  config.log_level = :warn
 end

--- a/test/cookbooks/nvidia_test/recipes/default.rb
+++ b/test/cookbooks/nvidia_test/recipes/default.rb
@@ -8,7 +8,7 @@ end
 include_recipe 'chef-yum-docker'
 include_recipe 'yum-epel'
 
-package %w(nvidia-docker2 nvidia-driver cuda)
+package %w(nvidia-docker2 nvidia-driver-latest cuda)
 
 service 'docker' do
   action [:start, :enable]

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -37,7 +37,7 @@ describe yum.repo('nvidia-docker') do
   its('baseurl') { should include nvidia_docker_url }
 end
 
-%w(nvidia-docker2 nvidia-driver cuda).each do |p|
+%w(nvidia-docker2 nvidia-driver-latest cuda).each do |p|
   describe package(p) do
     it { should be_installed }
   end


### PR DESCRIPTION
**Old ChefDK (before)**
- [x] Ensure all ChefSpec tests pass
- [x] Ensure all Inspec tests pass

**New ChefDK**
- [x] Ensure cookstyle is passing
- [x] Apply foodcritic fixes
- [x] Ensure `rake` passes
- [x] Ensure all Inspec tests pass

**Old ChefDK (after)**
- [x] Repeat all tests above using old ChefDK

Looks like the `cuda` package now installs `nvidia-driver-latest`, which conflicts with `nvidia-driver` and causes the test to fail. To remedy, I changed the `nvidia-driver` installation to be `nvidia-driver-latest`.