### PR TITLE
Fixes for Chef 15

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,6 @@
 AllCops:
-  Include:
-    - '**/Berksfile'
-    - '**/Cheffile'
-  Exclude:
-    - 'metadata.rb'
-
-Style/NumericLiteralPrefix:
-  EnforcedOctalStyle: zero_only
-
-Metrics/LineLength:
-  Max: 120
-
-Metrics/BlockLength:
-  Enabled: false
+  TargetChefVersion: 15.latest
+ChefModernize/FoodcriticComments:
+  Enabled: true
+ChefStyle/CopyrightCommentFormat:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -116,11 +116,6 @@ RuboCop::RakeTask.new(:style) do |task|
   task.options << '--display-cop-names'
 end
 
-desc 'Run FoodCritic (lint) tests'
-task :lint do
-  run_command('foodcritic --epic-fail any .')
-end
-
 desc 'Run RSpec (unit) tests'
 task :unit do
   run_command('rm -f Berksfile.lock')
@@ -128,6 +123,6 @@ task :unit do
 end
 
 desc 'Run all tests'
-task test: [:style, :lint, :unit]
+task test: [:style, :unit]
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ require 'base64'
 require 'chef/encrypted_data_bag_item'
 require 'json'
 require 'openssl'
+require 'cookstyle'
+require 'rubocop/rake_task'
 
 snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
 encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
@@ -90,7 +92,6 @@ file snakeoil_file_path => [
   'test/integration/data_bags/certificates',
   'test/integration/encrypted_data_bag_secret',
 ] do
-
   encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
     encrypted_data_bag_secret_path
   )
@@ -111,8 +112,8 @@ desc 'Create an Encrypted Databag Secret'
 task secret_file: encrypted_data_bag_secret_path
 
 desc 'Run RuboCop (cookstyle) tests'
-task :style do
-  run_command('cookstyle')
+RuboCop::RakeTask.new(:style) do |task|
+  task.options << '--display-cop-names'
 end
 
 desc 'Run FoodCritic (lint) tests'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,6 +2,12 @@
 verifier:
   name: inspec
 
+provisioner:
+  name: chef_solo
+  enforce_idempotency: true
+  multiple_converge: 2
+  deprecations_as_errors: true
+
 suites:
   - name: default
     run_list:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,6 @@ issues_url       'https://github.com/osuosl-cookbooks/yum-nvidia/issues'
 license          'Apache-2.0'
 chef_version     '>= 14.0'
 description      'Installs/Configures yum-nvidia'
-long_description 'Installs/Configures yum-nvidia'
 version          '1.1.1'
 
 supports         'centos', '~> 8.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: yum-nvidia
 # Recipe:: default
 #
-# Copyright:: 2019, Oregon State University
+# Copyright:: 2019-2020, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Straightforward changes except one thing.

I ran into trouble initially completing the integration testing until I set `repo_gpgcheck` to `false` for the `libnvidia-container`, `nvidia-container-runtime`, and `nvidia-docker` repos as it gave this error:

```log
     ================================================================================
     Error executing action `run` on resource 'execute[yum-makecache-nvidia-docker]'
     ================================================================================
     
     Mixlib::ShellOut::ShellCommandFailed
     ------------------------------------
     Expected process to exit with [0], but received ''
     ---- Begin output of yum -q -y makecache --disablerepo=* --enablerepo=nvidia-docker ----
     STDOUT: 
     STDERR: Importing GPG key 0xF796ECB0:
Userid     : "NVIDIA CORPORATION (Open Source Projects) <cudatools@nvidia.com>"
Fingerprint: C95B 321B 61E8 8C18 09C4 F759 DDCA E044 F796 ECB0
From       : https://nvidia.github.io/nvidia-docker/gpgkey
     ---- End output of yum -q -y makecache --disablerepo=* --enablerepo=nvidia-docker ----
     Ran yum -q -y makecache --disablerepo=* --enablerepo=nvidia-docker returned 
     
     Resource Declaration:
     ---------------------
     # In /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.15.6/lib/chef/provider/yum_repository.rb
     
60:         declare_resource(:execute, "yum-makecache-#{new_resource.repositoryid}") do
61:           command "yum -q -y makecache --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
62:           action :nothing
63:           only_if { new_resource.enabled }
64:         end
65: 
     
     Compiled Resource:
     ------------------
     # Declared in /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.15.6/lib/chef/provider/yum_repository.rb:60:in `block in <class:YumRepository>'
     
     execute("yum-makecache-nvidia-docker") do
action [:nothing]
default_guard_interpreter :execute
command "yum -q -y makecache --disablerepo=* --enablerepo=nvidia-docker"
backup 5
declared_type :execute
cookbook_name "yum-nvidia"
domain nil
user nil
only_if { #code block }
     end
     
     System Info:
     ------------
     chef_version=14.15.6
     platform=centos
     platform_version=8.1.1911
     ruby=ruby 2.5.8p224 (2020-03-31 revision 67882) [x86_64-linux]
     program_name=/opt/chef/bin/chef-solo
     executable=/opt/chef/bin/chef-solo
```

I didn't include that change in this PR as I wasn't sure if that would be acceptable. I also ran the command that was giving the problem in the VM and it finished with no issues so it's rather weird to me that it would error like this