### PR TITLE
Switch ppc64le to using upstream repositories

### DIFF
--- a/attributes/libnvidia-container.rb
+++ b/attributes/libnvidia-container.rb
@@ -1,18 +1,10 @@
-case node['kernel']['machine']
-when 'ppc64le'
-  default['yum']['libnvidia-container']['baseurl'] =
-    'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/libnvidia-container/$basearch'
-  default['yum']['libnvidia-container']['gpgcheck'] = true
-  default['yum']['libnvidia-container']['gpgkey'] = 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-else
-  default['yum']['libnvidia-container']['baseurl'] =
-    'https://nvidia.github.io/libnvidia-container/centos$releasever/$basearch'
-  default['yum']['libnvidia-container']['gpgcheck'] = false
-  default['yum']['libnvidia-container']['gpgkey'] = 'https://nvidia.github.io/libnvidia-container/gpgkey'
-  default['yum']['libnvidia-container']['repo_gpgcheck'] = true
-  default['yum']['libnvidia-container']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
-  default['yum']['libnvidia-container']['sslverify'] = true
-end
+default['yum']['libnvidia-container']['baseurl'] =
+  'https://nvidia.github.io/libnvidia-container/centos$releasever/$basearch'
+default['yum']['libnvidia-container']['gpgcheck'] = false
+default['yum']['libnvidia-container']['gpgkey'] = 'https://nvidia.github.io/libnvidia-container/gpgkey'
+default['yum']['libnvidia-container']['repo_gpgcheck'] = true
+default['yum']['libnvidia-container']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
+default['yum']['libnvidia-container']['sslverify'] = true
 default['yum']['libnvidia-container']['description'] = 'libnvidia-container'
 default['yum']['libnvidia-container']['enabled'] = true
 default['yum']['libnvidia-container']['failovermethod'] = 'priority'

--- a/attributes/nvidia-container-runtime.rb
+++ b/attributes/nvidia-container-runtime.rb
@@ -1,18 +1,10 @@
-case node['kernel']['machine']
-when 'ppc64le'
-  default['yum']['nvidia-container-runtime']['baseurl'] =
-    'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/nvidia-container-runtime/$basearch'
-  default['yum']['nvidia-container-runtime']['gpgcheck'] = true
-  default['yum']['nvidia-container-runtime']['gpgkey'] = 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-else
-  default['yum']['nvidia-container-runtime']['baseurl'] =
-    'https://nvidia.github.io/nvidia-container-runtime/centos$releasever/$basearch'
-  default['yum']['nvidia-container-runtime']['gpgcheck'] = false
-  default['yum']['nvidia-container-runtime']['gpgkey'] = 'https://nvidia.github.io/nvidia-container-runtime/gpgkey'
-  default['yum']['nvidia-container-runtime']['repo_gpgcheck'] = true
-  default['yum']['nvidia-container-runtime']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
-  default['yum']['nvidia-container-runtime']['sslverify'] = true
-end
+default['yum']['nvidia-container-runtime']['baseurl'] =
+  'https://nvidia.github.io/nvidia-container-runtime/centos$releasever/$basearch'
+default['yum']['nvidia-container-runtime']['gpgcheck'] = false
+default['yum']['nvidia-container-runtime']['gpgkey'] = 'https://nvidia.github.io/nvidia-container-runtime/gpgkey'
+default['yum']['nvidia-container-runtime']['repo_gpgcheck'] = true
+default['yum']['nvidia-container-runtime']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
+default['yum']['nvidia-container-runtime']['sslverify'] = true
 default['yum']['nvidia-container-runtime']['description'] = 'nvidia-container-runtime'
 default['yum']['nvidia-container-runtime']['enabled'] = true
 default['yum']['nvidia-container-runtime']['failovermethod'] = 'priority'

--- a/attributes/nvidia-docker.rb
+++ b/attributes/nvidia-docker.rb
@@ -1,17 +1,9 @@
-case node['kernel']['machine']
-when 'ppc64le'
-  default['yum']['nvidia-docker']['baseurl'] =
-    'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/nvidia-docker/$basearch'
-  default['yum']['nvidia-docker']['gpgcheck'] = true
-  default['yum']['nvidia-docker']['gpgkey'] = 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-else
-  default['yum']['nvidia-docker']['baseurl'] = 'https://nvidia.github.io/nvidia-docker/centos$releasever/$basearch'
-  default['yum']['nvidia-docker']['gpgcheck'] = false
-  default['yum']['nvidia-docker']['gpgkey'] = 'https://nvidia.github.io/nvidia-docker/gpgkey'
-  default['yum']['nvidia-docker']['repo_gpgcheck'] = true
-  default['yum']['nvidia-docker']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
-  default['yum']['nvidia-docker']['sslverify'] = true
-end
+default['yum']['nvidia-docker']['baseurl'] = 'https://nvidia.github.io/nvidia-docker/centos$releasever/$basearch'
+default['yum']['nvidia-docker']['gpgcheck'] = false
+default['yum']['nvidia-docker']['gpgkey'] = 'https://nvidia.github.io/nvidia-docker/gpgkey'
+default['yum']['nvidia-docker']['repo_gpgcheck'] = true
+default['yum']['nvidia-docker']['sslcacert'] = '/etc/pki/tls/certs/ca-bundle.crt'
+default['yum']['nvidia-docker']['sslverify'] = true
 default['yum']['nvidia-docker']['description'] = 'nvidia-docker'
 default['yum']['nvidia-docker']['enabled'] = true
 default['yum']['nvidia-docker']['failovermethod'] = 'priority'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ verifier:
   name: inspec
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -69,52 +69,6 @@ describe 'yum-nvidia::default' do
             sslverify: true
           )
       end
-      context 'ppc64le' do
-        cached(:chef_run) do
-          ChefSpec::SoloRunner.new(p) do |node|
-            node.automatic['kernel']['machine'] = 'ppc64le'
-          end.converge(described_recipe)
-        end
-        it do
-          expect(chef_run).to create_yum_repository('libnvidia-container')
-            .with(
-              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/libnvidia-container/$basearch',
-              description: 'libnvidia-container',
-              enabled: true,
-              failovermethod: 'priority',
-              gpgcheck: true,
-              gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
-              make_cache: true,
-              repositoryid: 'libnvidia-container'
-            )
-        end
-        it do
-          expect(chef_run).to create_yum_repository('nvidia-container-runtime')
-            .with(
-              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/nvidia-container-runtime/$basearch',
-              description: 'nvidia-container-runtime',
-              enabled: true,
-              failovermethod: 'priority',
-              gpgcheck: true,
-              gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
-              make_cache: true,
-              repositoryid: 'nvidia-container-runtime'
-            )
-        end
-        it do
-          expect(chef_run).to create_yum_repository('nvidia-docker')
-            .with(
-              baseurl: 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/nvidia-docker/$basearch',
-              description: 'nvidia-docker',
-              enabled: true,
-              failovermethod: 'priority',
-              gpgcheck: true,
-              gpgkey: 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
-              make_cache: true,
-              repositoryid: 'nvidia-docker'
-            )
-        end
-      end
     end
   end
 end

--- a/test/cookbooks/nvidia_test/metadata.rb
+++ b/test/cookbooks/nvidia_test/metadata.rb
@@ -1,5 +1,5 @@
 name 'nvidia_test'
 version '0.1.0'
 
-depends 'chef-yum-docker'
+depends 'docker'
 depends 'yum-epel'

--- a/test/cookbooks/nvidia_test/recipes/default.rb
+++ b/test/cookbooks/nvidia_test/recipes/default.rb
@@ -1,25 +1,7 @@
-if node['kernel']['machine'] == 'ppc64le'
-  node.default['yum']['docker-stable']['baseurl'] =
-    'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/docker-stable/$basearch'
-  node.default['yum']['docker-stable']['gpgcheck'] = true
-  node.default['yum']['docker-stable']['gpgkey'] = 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
-end
-
-if node['platform_version'].to_i >= 8
-  yum_repository 'Docker' do
-    baseurl 'https://download.docker.com/linux/centos/7/x86_64/stable'
-    gpgkey 'https://download.docker.com/linux/centos/gpg'
-    description 'Docker Stable repository'
-    gpgcheck true
-    enabled true
-    # Enable all rpms to workaround modularity issue:
-    # https://forums.docker.com/t/yum-repo-for-centos-8/81884/8
-    options(module_hotfixes: true)
-  end
-else
-  include_recipe 'chef-yum-docker'
-end
+# Needed for dkms
 include_recipe 'yum-epel'
+
+docker_installation_package 'default'
 
 nvidia_driver = node['platform_version'].to_i >= 8 ? 'nvidia-driver' : 'nvidia-driver-latest-dkms'
 

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,21 +1,13 @@
-# Inspec test for recipe yum-nvidia::default
-
-# The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
 release = os.release.to_i
-if os.arch == 'ppc64le'
-  libnvidia_container_url = "https://ftp.osuosl.org/pub/osl/repos/yum/#{release}/libnvidia-container/ppc64le"
-  nvidia_container_runtime_url = "https://ftp.osuosl.org/pub/osl/repos/yum/#{release}/nvidia-container-runtime/ppc64le"
-  nvidia_docker_url = "https://ftp.osuosl.org/pub/osl/repos/yum/#{release}/nvidia-docker/ppc64le"
-else
-  libnvidia_container_url = "https://nvidia.github.io/libnvidia-container/centos#{release}/x86_64"
-  nvidia_container_runtime_url = "https://nvidia.github.io/nvidia-container-runtime/centos#{release}/x86_64"
-  nvidia_docker_url = "https://nvidia.github.io/nvidia-docker/centos#{release}/x86_64"
-end
+arch = os.arch
+libnvidia_container_url = "https://nvidia.github.io/libnvidia-container/centos#{release}/#{arch}"
+nvidia_container_runtime_url = "https://nvidia.github.io/nvidia-container-runtime/centos#{release}/#{arch}"
+nvidia_docker_url = "https://nvidia.github.io/nvidia-docker/centos#{release}/#{arch}"
+
 describe yum.repo('cuda') do
   it { should exist }
   it { should be_enabled }
-  its('baseurl') { should include "https://developer.download.nvidia.com/compute/cuda/repos/rhel#{release}/#{os.arch}" }
+  its('baseurl') { should include "https://developer.download.nvidia.com/compute/cuda/repos/rhel#{release}/#{arch}" }
 end
 
 describe yum.repo('libnvidia-container') do


### PR DESCRIPTION
Nvidia now provides proper repositories for ppc64le so let's point to that now and update the tests.

In addition, change from using chef-yum-docker to the docker cookbook for testing.

Signed-off-by: Lance Albertson <lance@osuosl.org>
